### PR TITLE
Fix wrong interpolation in interpolateArray

### DIFF
--- a/utils/interpolate.js
+++ b/utils/interpolate.js
@@ -24,7 +24,7 @@ function interpolate (a, b) {
 }
 
 function interpolateArray (scaleArr) {
-  var N = scaleArr.length - 1 // -1 for spacings, -1 for number of interpolate fns
+  var N = scaleArr.length - 1 // -1 for number of interpolate fns
   var intervalWidth = 1 / N
   var intervals = []
 

--- a/utils/interpolate.js
+++ b/utils/interpolate.js
@@ -24,21 +24,22 @@ function interpolate (a, b) {
 }
 
 function interpolateArray (scaleArr) {
-  var N = scaleArr.length - 2 // -1 for spacings, -1 for number of interpolate fns
+  var N = scaleArr.length - 1 // -1 for spacings, -1 for number of interpolate fns
   var intervalWidth = 1 / N
   var intervals = []
 
-  for (var i = 0; i <= N; i++) {
+  for (var i = 0; i < N; i++) {
     intervals[i] = interpolate(scaleArr[i], scaleArr[i + 1])
   }
 
   return function (t) {
     if (t < 0 || t > 1) throw new Error('Outside the allowed range of [0, 1]')
+    
+    var fractionalLocation = t * N
+    var i = Math.max(Math.ceil(fractionalLocation - 1), 0)
+    var intervalOffset = fractionalLocation - i
 
-    var i = Math.floor(t * N)
-    var intervalOffset = i * intervalWidth
-
-    return intervals[i](t / intervalWidth - intervalOffset / intervalWidth)
+    return intervals[i](intervalOffset)
   }
 }
 


### PR DESCRIPTION
Previous implementation didn't interpolate up to the last element in scaleArr,
one would expect that
interpolateArray([1,2,3,4,5])(1) == 5
but the output was 4, interpolateArray([1,2,3,4,5])(0.5) was 2.5 instead of 3,
e.g. it treated the input array as it were one element shorter.
This implementation behaves in such a way that
interpolateArray([1,2,3,4,5])(1) == 5
interpolateArray([1,2,3,4,5])(0) == 1
interpolateArray([1,2,3,4,5])(0.5) == 3